### PR TITLE
Release Bump.

### DIFF
--- a/gkrellm-themes.spec
+++ b/gkrellm-themes.spec
@@ -1,6 +1,6 @@
 %define name	gkrellm-themes
 %define version	20030129
-%define release	12
+%define release	13
 
 Name:		%{name}
 Version:	%{version}


### PR DESCRIPTION
Because in 4.0 dnf keeps wanting to install non-existing gkrellm-themes-20030129-12-omv2015.0 instead of the existing gkrellm-themes-20030129-12-omv4000. So I'm *hoping* this will correct the issue for users.